### PR TITLE
Allow context: apps running over lockscreen (lock screen camera) 

### DIFF
--- a/src/com/spazedog/xposed/additionsgb/backend/pwm/PhoneWindowManager.java
+++ b/src/com/spazedog/xposed/additionsgb/backend/pwm/PhoneWindowManager.java
@@ -308,7 +308,7 @@ public final class PhoneWindowManager {
 							/*
 							 * Prepare the event information for this key or key combo.
 							 */
-							mEventManager.registerEvent(mMediator.getPackageNameFromStack(0, StackAction.INCLUDE_HOME), mMediator.isKeyguardLocked(), isScreenOn);
+							mEventManager.registerEvent(mMediator.getPackageNameFromStack(0, StackAction.INCLUDE_HOME), mMediator.isKeyguardShowing(), isScreenOn);
 							
 							/*
 							 * If the screen is off, it's a good idea to poke the device out of deep sleep. 


### PR DESCRIPTION
Previously, any app running over the lockscreen just has the context
"guard". With this change, the lockscreen itself reports as "guard", but
apps (like Camera) will use their own contexts.

The major scenario here is that of the lock screen camera: it should use the Camera context but previously doesn't. With this change, the Camera context is correctly triggered when the Camera comes up over the lock screen, but the lock screen still uses the "guard" context. 
